### PR TITLE
Fix typo 'abortificant'

### DIFF
--- a/autocorrect.vim
+++ b/autocorrect.vim
@@ -127,7 +127,7 @@ ia abondons abandons
 ia Abondons Abandons
 ia aborigene aborigine
 ia Aborigene Aborigine
-ia abortificant abortifacient
+ia abortifacient abortifacient
 ia Abortificant Abortifacient
 ia abreviated abbreviated
 ia Abreviated Abbreviated

--- a/autocorrect.vim
+++ b/autocorrect.vim
@@ -113,7 +113,7 @@ ia abandonned abandoned
 ia Abandonned Abandoned
 ia aberation aberration
 ia Aberation Aberration
-ia abilties abilities
+ia abilities abilities
 ia Abilties Abilities
 ia abilty ability
 ia Abilty Ability


### PR DESCRIPTION
```
Hi! I'm a bot that checks GitHub for spelling mistakes, and I found one in your repository. When it
should be 'abortifacient', you typed 'abortificant'. I created this pull request to fix it!

If you think there is anything wrong with this pull request or just have a question, be kind to mail me 
at thetypomaster@hotmail.com (professional email, huh?). I’ll try to address the problem as soon as
I’m aware of it.

Looking for the source code of this bot? Well, you have to be patient! The bot is under development
and I will publish the source code as soon as I’m finished with it.

With kind regards,
TheTypoMaster
```
